### PR TITLE
Move to new @ai-sdk/provider package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "node-addon-api": "^8.0.0"
       },
       "devDependencies": {
+        "@ai-sdk/provider": "^0.0.0",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.2",
         "cmake-js": "^7.3.0",
@@ -21,7 +22,19 @@
         "typescript": "^5.4.3"
       },
       "peerDependencies": {
-        "ai": "^3.0.16"
+        "ai": "^3.0.20"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.0.tgz",
+      "integrity": "sha512-Gbl9Ei8NPtM85gB/o8cY7s7CLGxK/U6QVheVaI3viFn7o6IpTfy1Ja389e2FXVMNJ4WHK2qYWSp5fAFDuKulTA==",
+      "dev": true,
+      "dependencies": {
+        "json-schema": "0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1534,6 +1547,12 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "peer": true
+    },
     "node_modules/@types/node": {
       "version": "20.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.2.tgz",
@@ -1688,13 +1707,15 @@
       }
     },
     "node_modules/ai": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-3.0.16.tgz",
-      "integrity": "sha512-P6GGUYbE8PDUVeGT9D7tT9nF7lufDjbieZ97YVIVL/eZkGcfXQMvJleO1VzJ1eutoI8f5Llazmhg4K66Gs5q3Q==",
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-3.0.20.tgz",
+      "integrity": "sha512-W5J7lNrqxBA5aQmWEV4V5AtEE3yGRMQ9l4kipIXeS3+RTds1V3cgmKjQwgASPS5Jn/9IgrUEER/Est0V1rU/NA==",
       "peer": true,
       "dependencies": {
+        "@types/json-schema": "7.0.15",
         "eventsource-parser": "1.1.2",
-        "jsondiffpatch": "^0.6.0",
+        "json-schema": "0.4.0",
+        "jsondiffpatch": "0.6.0",
         "nanoid": "3.3.6",
         "secure-json-parse": "2.7.0",
         "solid-swr-store": "0.10.7",
@@ -1702,7 +1723,7 @@
         "swr": "2.2.0",
         "swr-store": "0.10.6",
         "swrv": "1.0.4",
-        "zod-to-json-schema": "^3.22.4"
+        "zod-to-json-schema": "3.22.5"
       },
       "engines": {
         "node": ">=14.6"
@@ -3919,6 +3940,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "node_modules/json5": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Nick Nance",
   "license": "MIT",
   "devDependencies": {
+    "@ai-sdk/provider": "^0.0.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.2",
     "cmake-js": "^7.3.0",
@@ -30,7 +31,7 @@
     "typescript": "^5.4.3"
   },
   "peerDependencies": {
-    "ai": "^3.0.16"
+    "ai": "^3.0.20"
   },
   "files": [
     "dist",

--- a/src/llamacpp-chat-language-model.test.ts
+++ b/src/llamacpp-chat-language-model.test.ts
@@ -2,7 +2,7 @@ import {
   LanguageModelV1CallOptions,
   LanguageModelV1Prompt,
   LanguageModelV1StreamPart,
-} from "ai/spec";
+} from "@ai-sdk/provider";
 import {
   LLamaCppAdapter,
   LLamaCppEvaluateOptions,

--- a/src/llamacpp-chat-language-model.ts
+++ b/src/llamacpp-chat-language-model.ts
@@ -10,7 +10,7 @@ import {
   LanguageModelV1TextPart,
   LanguageModelV1ToolCallPart,
   LanguageModelV1ToolResultPart,
-} from "ai/spec";
+} from "@ai-sdk/provider";
 import { Message } from "ai";
 
 import { experimental_buildLlama2Prompt } from "ai/prompts";

--- a/src/llamacpp-completion-language-model.ts
+++ b/src/llamacpp-completion-language-model.ts
@@ -5,7 +5,7 @@ import {
   LanguageModelV1FunctionToolCall,
   LanguageModelV1StreamPart,
   LanguageModelV1FinishReason,
-} from "ai/spec";
+} from "@ai-sdk/provider";
 import { LLamaCppAdapter } from "./llamacpp-adapter.js";
 
 interface LLamaCppCompletionConfig {


### PR DESCRIPTION
The AI SDK has a separate provider package now. I've updated the code to check if it works. However, because of the `npm install` issue, I was not able to test it.